### PR TITLE
match the spec for structs and seqs when these contain Dim elements

### DIFF
--- a/dap4/dap4.xsd
+++ b/dap4/dap4.xsd
@@ -256,21 +256,33 @@
     </xs:complexType>
 
     <xs:complexType name="StructureType">
-        <xs:complexContent>
-            <xs:extension base="BaseType">
-                <xs:group ref="VariableTypes" minOccurs="1" maxOccurs="unbounded"/>
-            </xs:extension>
-        </xs:complexContent>
+        <xs:annotation>
+            <xs:documentation>A Structure groups a list of variables so that the
+            collection can be manipulated as a single item. The fields (or Variables)
+            in a Structure MAY be of any type, including Structure or Sequence. The 
+            order of items in the Structure is significant only in relation to the 
+            serialized representation of that Structure.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:group ref="VariableTypes" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element ref="Dim" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string"/>
     </xs:complexType>
 
-
-    <xs:complexType name="SequenceType">
-        <xs:complexContent>
-            <xs:extension base="BaseType">
-                <xs:group ref="VariableTypes" minOccurs="1" maxOccurs="unbounded"/>
-            </xs:extension>
-        </xs:complexContent>
+   <xs:complexType name="SequenceType">
+        <xs:annotation>
+            <xs:documentation>A Sequence is intended to represent a sequence of instances of objects.
+            A Sequence was introduced to replace the concept of variable length dimensions.
+            .</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:group ref="VariableTypes" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element ref="Dim" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string"/>
     </xs:complexType>
+
 
     <xs:simpleType name="EnumBaseType">
         <xs:restriction base="xs:string">

--- a/dap4/dap4.xsd
+++ b/dap4/dap4.xsd
@@ -273,9 +273,8 @@
    <xs:complexType name="SequenceType">
         <xs:annotation>
             <xs:documentation>A Sequence, introduced to replace the concept of variable 
-            length dimensions is a generalization of a Table, is intended to represent 
-            a sequence of instances of objects
-            .</xs:documentation>
+            length dimensions, is a generalization of a Table intended to represent 
+            a sequence of instances of objects.</xs:documentation>
         </xs:annotation>
         <xs:sequence>
             <xs:group ref="VariableTypes" minOccurs="1" maxOccurs="unbounded"/>

--- a/dap4/dap4.xsd
+++ b/dap4/dap4.xsd
@@ -272,8 +272,9 @@
 
    <xs:complexType name="SequenceType">
         <xs:annotation>
-            <xs:documentation>A Sequence is intended to represent a sequence of instances of objects.
-            A Sequence was introduced to replace the concept of variable length dimensions.
+            <xs:documentation>A Sequence, introduced to replace the concept of variable 
+            length dimensions is a generalization of a Table, is intended to represent 
+            a sequence of instances of objects
             .</xs:documentation>
         </xs:annotation>
         <xs:sequence>

--- a/tests/data/Structure_test3.dmr
+++ b/tests/data/Structure_test3.dmr
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Dataset
+         name="test_struct_array.nc"
+         dapVersion="4.0"
+         dmrVersion="1.0"
+         xmlns="http://xml.opendap.org/ns/DAP/4.0#"
+         xmlns:dap="http://xml.opendap.org/ns/DAP/4.0#">
+    <Structure name="s">
+        <Int32 name="x"/>
+        <Int32 name="y"/>
+        <Dim size="2"/>
+        <Dim size="2"/>
+    </Structure>
+    <Attribute name="_dap4.ce" type="String">
+        <Value value="/s[0:2:3][0:1]"/>
+    </Attribute>
+    <Attribute name="_DAP4_Little_Endian" type="UInt8">
+        <Value value="1"/>
+    </Attribute>
+    <Attribute name="_NCProperties" type="String">
+        <Value value="version=2,netcdf=4.9.1-development,hdf5=1.12.2"/>
+    </Attribute>
+</Dataset>


### PR DESCRIPTION
This is a ~DRAFT~ PR:

- [x] Changes the schema to match the spec for when `Dim` elements are declarated within Sequences and Structures. See #11 
- [x] Adds a test file
- [x] All tests pass locally  